### PR TITLE
Medius 1.8 MUIS Support

### DIFF
--- a/RT.Common/Constants.cs
+++ b/RT.Common/Constants.cs
@@ -27,6 +27,7 @@ namespace RT.Common
         public const int MEDIUS_GENERIC_CHAT_FILTER_BYTES_LEN = 16;
         public const int MEDIUS_MESSAGE_MAXLEN = 512;
         public const int MEDIUS_UDP_MESSAGE_MAXLEN = 1024;
+        public const int NEWS_MAXLEN = 256;
         public const int POLICY_MAXLEN = 256;
         public const int PLAYERNAME_MAXLEN = 32;
         public const int APPNAME_MAXLEN = 32;

--- a/RT.Models/Lobby/MediusUniverseNewsResponse.cs
+++ b/RT.Models/Lobby/MediusUniverseNewsResponse.cs
@@ -27,10 +27,10 @@ namespace RT.Models
 
             //
             MessageID = reader.Read<MessageId>();
+            reader.ReadBytes(3);
             StatusCode = reader.Read<MediusCallbackStatus>();
 
             // 
-            reader.ReadBytes(3);
             News = reader.ReadString(Constants.NEWS_MAXLEN);
             EndOfList = reader.ReadBoolean();
             reader.ReadBytes(3);
@@ -43,10 +43,10 @@ namespace RT.Models
 
             //
             writer.Write(MessageID ?? MessageId.Empty);
+            writer.Write(new byte[3]);
             writer.Write(StatusCode);
 
             // 
-            writer.Write(new byte[3]);
             writer.Write(News, Constants.NEWS_MAXLEN);
             writer.Write(EndOfList);
             writer.Write(new byte[3]);

--- a/RT.Models/Lobby/MediusUniverseNewsResponse.cs
+++ b/RT.Models/Lobby/MediusUniverseNewsResponse.cs
@@ -16,9 +16,9 @@ namespace RT.Models
 
         public MessageId MessageID { get; set; }
 
-        public string Text; // CHATMESSAGE_MAXLEN
+        public string News; // NEWS_MAXLEN
         public MediusCallbackStatus StatusCode;
-        public int EndOfList;
+        public bool EndOfList;
 
         public override void Deserialize(BinaryReader reader)
         {
@@ -27,11 +27,13 @@ namespace RT.Models
 
             //
             MessageID = reader.Read<MessageId>();
+            StatusCode = reader.Read<MediusCallbackStatus>();
 
             // 
-            Text = reader.ReadString(Constants.CHATMESSAGE_MAXLEN);
-            //reader.ReadBytes(3);
-            //StatusCode = reader.Read<MediusCallbackStatus>();
+            reader.ReadBytes(3);
+            News = reader.ReadString(Constants.NEWS_MAXLEN);
+            EndOfList = reader.ReadBoolean();
+            reader.ReadBytes(3);
         }
 
         public override void Serialize(BinaryWriter writer)
@@ -45,8 +47,9 @@ namespace RT.Models
 
             // 
             writer.Write(new byte[3]);
-            writer.Write(Text, 256);
+            writer.Write(News, Constants.NEWS_MAXLEN);
             writer.Write(EndOfList);
+            writer.Write(new byte[3]);
             
         }
 
@@ -55,7 +58,9 @@ namespace RT.Models
         {
             return base.ToString() + " " +
                 $"MessageID:{MessageID} " +
-             $"Text:{Text} ";
+                $"StatusCode:{StatusCode} " +
+                $"News:{News} " +
+             $"EndOfList:{EndOfList} ";
         }
     }
 }

--- a/RT.Models/Lobby/MediusUniverseNewsResponse.cs
+++ b/RT.Models/Lobby/MediusUniverseNewsResponse.cs
@@ -1,0 +1,61 @@
+using RT.Common;
+using Server.Common;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace RT.Models
+{
+	[MediusMessage(NetMessageTypes.MessageClassLobby, MediusLobbyMessageIds.UniverseNewsResponse)]
+    public class MediusUniverseNewsResponse : BaseLobbyMessage, IMediusResponse
+    {
+		public override byte PacketType => (byte)MediusLobbyMessageIds.UniverseNewsResponse;
+
+        public bool IsSuccess => StatusCode >= 0;
+
+        public MessageId MessageID { get; set; }
+
+        public string Text; // CHATMESSAGE_MAXLEN
+        public MediusCallbackStatus StatusCode;
+        public int EndOfList;
+
+        public override void Deserialize(BinaryReader reader)
+        {
+            // 
+            base.Deserialize(reader);
+
+            //
+            MessageID = reader.Read<MessageId>();
+
+            // 
+            Text = reader.ReadString(Constants.CHATMESSAGE_MAXLEN);
+            //reader.ReadBytes(3);
+            //StatusCode = reader.Read<MediusCallbackStatus>();
+        }
+
+        public override void Serialize(BinaryWriter writer)
+        {
+            // 
+            base.Serialize(writer);
+
+            //
+            writer.Write(MessageID ?? MessageId.Empty);
+            writer.Write(StatusCode);
+
+            // 
+            writer.Write(new byte[3]);
+            writer.Write(Text, 256);
+            writer.Write(EndOfList);
+            
+        }
+
+
+        public override string ToString()
+        {
+            return base.ToString() + " " +
+                $"MessageID:{MessageID} " +
+             $"Text:{Text} ";
+        }
+    }
+}

--- a/RT.Models/RT/RT_MSG_SERVER_CONNECT_ACCEPT_TCP.cs
+++ b/RT.Models/RT/RT_MSG_SERVER_CONNECT_ACCEPT_TCP.cs
@@ -17,13 +17,15 @@ namespace RT.Models
         // 
         public ushort UNK_00 = 0x0000;
         public uint UNK_02 = 0x10EC;
-
         public ushort UNK_06 = 0x0001;
 
+        public byte[] UNK_07 = {0x01, 0x08, 0x10, 0x00, 0x00};
+        public bool OldMedius = false;
         public IPAddress IP;
 
         public override void Deserialize(BinaryReader reader)
-        {
+        {            
+            
             UNK_00 = reader.ReadUInt16();
             UNK_02 = reader.ReadUInt32();
             UNK_06 = reader.ReadUInt16();
@@ -33,14 +35,25 @@ namespace RT.Models
 
         protected override void Serialize(BinaryWriter writer)
         {
-            writer.Write(UNK_00);
-            writer.Write(UNK_02);
-            writer.Write(UNK_06);
+            if (OldMedius == false){
+                writer.Write(UNK_00);
+                writer.Write(UNK_02);
+                writer.Write(UNK_06);
 
-            if (IP == null)
-                writer.Write(IPAddress.Any);
-            else
-                writer.Write(IP);
+                if (IP == null)
+                    writer.Write(IPAddress.Any);
+                else
+                    writer.Write(IP);
+            }
+            else{
+                writer.Write(UNK_07);
+                writer.Write(UNK_06);
+
+                if (IP == null)
+                    writer.Write(IPAddress.Any);
+                else
+                    writer.Write(IP);
+            }
         }
 
         public override string ToString()

--- a/Server.UniverseInformation/MUIS.cs
+++ b/Server.UniverseInformation/MUIS.cs
@@ -323,8 +323,8 @@ namespace Server.UnivereInformation
                                     {
                                         MessageID = getUniverseInfo.MessageID,
                                         StatusCode = MediusCallbackStatus.MediusSuccess,
-                                        Text = "News!",
-                                        EndOfList = 1
+                                        News = "News!",
+                                        EndOfList = true
                                     }
                                 }, clientChannel);
                             }


### PR DESCRIPTION
Allows games using protocol version 1.8 (such as Killzone) to connect to the MUIS endpoint and retrieve universe information.